### PR TITLE
Improve script

### DIFF
--- a/Docker_Pull_Issue_Test/DockerPull.sh
+++ b/Docker_Pull_Issue_Test/DockerPull.sh
@@ -43,7 +43,10 @@ function pull_image() {
         print_color "green" "\n Pod $1 does not exist."
     fi
     print_color "green" "Pulling $1 Image and Running it \n"
-    kubectl run $1 --image=$1
+
+    # Ensure it always makes a call to the remote registry
+    kubectl run $1 --image=$1 --image-pull-policy Always
+
     # We don't guess how long it takes a pod to be ready. We ask API server :-)
     if kubectl wait pod $1 --for condition=Ready --timeout 30s
     then

--- a/Docker_Pull_Issue_Test/DockerPull.sh
+++ b/Docker_Pull_Issue_Test/DockerPull.sh
@@ -9,6 +9,9 @@ echo "         Docker Pull Test           "
 echo "         -Iamrushabhshahh-          "
 echo "===================================="
 
+MIRROR_REPO=docker-registry-mirror.kodekloud.com
+MIRROR_ADDR=10.0.0.6
+
 #######################################
 # Print the message in given color.
 # Arguments:
@@ -32,87 +35,99 @@ function print_color() {
 #######################################
 
 function pull_image() {
-    if kubectl get pods | grep -q "$1"; then
+    if  [ ! -z $(kubectl  get po -o json | jq -r '.items[] | select(.metadata.name == "'$1'") | .metadata.name') ]
+    then
         print_color "green" " \n Pod $1 exists. Deleting it..."
         kubectl delete pod "$1"
-        print_color "green" "\n Pod $1 has been deleted."
     else
-        print_color "green" "\n Pod $1 does not exist. \n Pulling $1 Image and Running it \n"
+        print_color "green" "\n Pod $1 does not exist."
     fi
+    print_color "green" "Pulling $1 Image and Running it \n"
     kubectl run $1 --image=$1
-    sleep 10
-    print_color "green" " \n"
-    kubectl get pod
+    # We don't guess how long it takes a pod to be ready. We ask API server :-)
+    if kubectl wait pod $1 --for condition=Ready --timeout 30s
+    then
+        print_color "green" " Pod $1 started successfully"
+        kubectl get pod $1
+        kubectl delete pod $1
+    else
+        print_color "red" " Pod $1 has not started"
+        kubectl get pod
+    fi
 }
 
 # Check Host Entries for Docker Registry | Check this for all Enviornments
 print_color "green" "\n Checking Host Entries for Docker Registry \n"
-grep "10.0.0.6 docker-registry-mirror.kodekloud.com" /etc/hosts
-if [ $? -eq 0 ]; then
+if egrep "${MIRROR_ADDR}\s+${MIRROR_REPO}" /etc/hosts > /dev/null
+then
     print_color "green" " \n Hosts File Entry Exists \n"
 else
     print_color "red" "\n Hosts File Entry Does Not Exist \n"
+    # Stop here since if the host doesn't exist, nothing will work!
+    exit 1
 fi
 
-# CHECK DOCKER
-which docker
-if [ $? -eq 0 ]; then
+if command -v docker > /dev/null
+then
     print_color "green" " \n Docker is Installed $(docker --version) \n"
-    cat /etc/docker/daemon.json | grep "docker-registry-mirror.kodekloud.com"
-    if [ $? -eq 0 ]; then
-        print_color "green" " \n Config File Entry Exists at /etc/docker/daemon.json"
+    if grep "${MIRROR_REPO}" /etc/docker/daemon.json > /dev/null
+    then
+        print_color "green" " \n Mirror repo found in /etc/docker/daemon.json"
         print_color "green" " \n Checking For Docker Pull"
-        # docker run docker/whalesay KodeKloud #Chcecking Docker pull
-        docker pull redis  
+        if docker pull redis
+        then
+            print_color "green" "Pull successful"
+        else
+            print_color "red" "Pull FAILED"
+        fi
     else
-        print_color "red" " \n Config File Doesn't have the docker repository link \n"
-        cat /etc/docker/daemon.json
+        print_color "red" " \n Mirror repo NOT FOUND in /etc/docker/daemon.json"
     fi
 else
     print_color "red" "\n Docker is Not Installed"
-    print_color "green" "\n Checking For Kubernetes"
-    # CHECK KUBERNETES CLUSTER
-    kubectl get all
-    systemctl status containerd.service >/dev/null # Check if containerd is running
-    if [ $? -eq 0 ]; then
-        print_color "green" "\n Containerd Service is Running"
-        grep "docker-registry-mirror.kodekloud.com" /etc/containerd/config.toml
-        if [ $? -eq 0 ]; then
-            print_color "green" "\n Config File Entry Exists at /etc/containerd/config.toml"
-            pull_image nginx
-        else
-            print_color "red" "\n Config.toml Doesn't have the docker repository link \n"
-            pull_image nginx
-        fi
-    else
-        print_color "red" "\nContainerd Service is Not Running | This Might K3s Node "
-        print_color "green" "\n Checking in /var/lib/rancher/k3s/agent/etc/containerd/certs.d \n"
-        ls -l /var/lib/rancher/k3s/agent/etc/containerd/certs.d | grep "docker-registry-mirror.kodekloud.com"
-        if [ $? -eq 0 ]; then
-            print_color "green" "\n Config File Entry Exists at /var/lib/rancher/k3s/agent/etc/containerd/certs.d \n"
-            ls -l /var/lib/rancher/k3s/agent/etc/containerd/certs.d
-            pull_image nginx
-        else
-            print_color "red" "\n Certs.d Doesn't have the docker repository link \n"
-            cat /var/lib/rancher/k3s/agent/etc/containerd/config.toml | grep "docker-registry-mirror.kodekloud.com"
-            if [ $? -eq 0 ]; then
-                print_color "green" "Config File Entry Exists at /var/lib/rancher/k3s/agent/etc/containerd/config.toml"
-                pull_image nginx
-            else
-                print_color "red" "Config.toml Doesn't have the docker repository link \n"
-                ls -l /var/lib/rancher/k3s/agent/etc/containerd/
-                pull_image nginx
-            fi
-        fi
-    fi
 fi
 
+# It is surely possible to have both kube and docker installed in a lab or playground
+# where a user might want to build an image, then deploy to cluster.
+if command -v kubectl > /dev/null
+then
+    print_color green "kubectl detected. Examining kubernetes"
+    K8S_CONFIG=""
+    if command -v systemctl > /dev/null
+    then
+        if systemctl status containerd.service >/dev/null
+        then
+            print_color green "Kubernetes: kubeadm"
+            K8S_CONFIG=/etc/containerd/config.toml
+        fi
+    fi
+    if [ -z $K8S_CONFIG ]
+    then
+        print_color green "Kubernetes: K3S"
+        K8S_CONFIG=/var/lib/rancher/k3s/agent/etc/containerd/certs.d/docker-registry-mirror.kodekloud.com/hosts.toml
+        [ -f $K8S_CONFIG ] || K8S_CONFIG=/var/lib/rancher/k3s/agent/etc/containerd/config.toml
+    fi
+
+    if grep $MIRROR_REPO $K8S_CONFIG > /dev/null
+    then
+        print_color "green" "\n Mirror repo found in ${K8S_CONFIG} - testing pull"
+        pull_image nginx
+    else
+        print_color "red" "\n Mirror repo NOT FOUND in ${K8S_CONFIG}"
+    fi
+else
+    print_color green "kubectl not found. Assuming no kubernetes in ths lab."
+fi
+
+
 print_color "green" "\n Rate Limit Check From Docker \n"
-TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-print_color "green" "Below is the Count \n"
-curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
-
-
+TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+curl -Is -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest > rate.tmp
+echo "- Limit: $(cat rate.tmp | awk '/ratelimit-limit:/ { print $2 }' | cut -d ';' -f 1)"
+echo "- Remaining: $(cat rate.tmp | awk '/ratelimit-remaining:/ { print $2 }' | cut -d ';' -f 1)"
+echo "- Public IP: $(cat rate.tmp | awk '/docker-ratelimit-source:/ { print $2 }')"
+echo
+rm -f rate.tmp
 print_color "green" "\n===================================="
 print_color "green" "     Docker Pull Test Completed     "
 print_color "green" "         -Iamrushabhshahh-          "


### PR DESCRIPTION
* Use shell vars for repeated strings
* Reduce cyclomatic complexity (all the nested `if`'s)
* Exit script if `/etc/hosts` isn't fixed, because nothing will work without that
     * Improve grep for this check
* Ensure image is always pulled from remote registry (pull policy), or it's not a valid test.
* Use a proper check for a pod being ready
* Use a quieter method to detect pod already running
* Make the limit check output nicer

Remember to run script on all nodes in a multi-node cluster lab ;-)